### PR TITLE
編集ドキュメントオブジェクトを構成するサブクラス群のリファクタリング

### DIFF
--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -36,9 +36,11 @@
 #include "debug/CRunningTimer.h"
 #include "_os/CClipboard.h"
 
+/*!
+ * コンストラクタ
+ */
 CDocEditor::CDocEditor(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
-	, m_pcDocRef(CEditDoc::getInstance())
 , m_cNewLineCode( EEolType::cr_and_lf )		//	New Line Type
 , m_pcOpeBlk( NULL )
 , m_bInsMode( true )	// Oct. 2, 2005 genta

--- a/sakura_core/doc/CDocEditor.h
+++ b/sakura_core/doc/CDocEditor.h
@@ -30,10 +30,12 @@
 #include "doc/CDocListener.h"
 #include "COpeBuf.h"
 
-class CEditDoc;
 class CDocLineMgr;
 
-class CDocEditor : public ShareDataAccessorClient, public CDocListenerEx
+/*!
+ * ドキュメントエディタークラス
+ */
+class CDocEditor : public ShareDataAccessorClient, public CDocListenerEx, private CDocRefClient
 {
 public:
 	explicit CDocEditor(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
@@ -88,7 +90,6 @@ public:
 	bool IsEnablePaste( void ) const;
 
 public:
-	CEditDoc*		m_pcDocRef;
 	CEol 			m_cNewLineCode;				//!< Enter押下時に挿入する改行コード種別
 	COpeBuf			m_cOpeBuf;					//!< アンドゥバッファ
 	COpeBlk*		m_pcOpeBlk;					//!< 操作ブロック

--- a/sakura_core/doc/CDocFile.h
+++ b/sakura_core/doc/CDocFile.h
@@ -56,9 +56,13 @@ public:
 	void	SetFileTime( FILETIME& Time )			{ cFileTime.SetFILETIME( Time ); }
 };
 
+/*!
+ * 編集中ドキュメントのファイル管理クラス
+ */
 class CDocFile : public CFile{
 public:
-	CDocFile(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) {}
+	CDocFile() = default;
+	~CDocFile() override = default;
 
 	void			SetCodeSet(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.SetCodeSet(eCodeSet, bBomExist); }	//!< 文字コードセットを設定
 	void			SetCodeSetChg(ECodeType eCodeSet , bool bBomExist)	{ m_sFileInfo.eCharCode = eCodeSet; m_sFileInfo.bBomExist = bBomExist; }	//!< 文字コードセットを設定(文字コード指定用)
@@ -78,7 +82,6 @@ public:
 	const WCHAR*	GetSaveFilePath(void) const;
 	void			SetSaveFilePath(LPCWSTR pszPath){ m_szSaveFilePath.Assign(pszPath); }
 public: //####
-	CEditDoc*	m_pcDocRef;
 	SFileInfo	m_sFileInfo;
 	CFilePath	m_szSaveFilePath;	/* 保存時のファイルのパス（マクロ用） */	// 2006.09.04 ryoji
 };

--- a/sakura_core/doc/CDocFileOperation.h
+++ b/sakura_core/doc/CDocFileOperation.h
@@ -30,11 +30,13 @@
 #include "doc/CDocListener.h" // SLoadInfo
 #include "CEol.h"
 
-class CEditDoc;
-
-class CDocFileOperation{
+/*!
+ * 編集中ドキュメントのファイル操作クラス
+ */
+class CDocFileOperation : private CDocRefClient
+{
 public:
-	CDocFileOperation(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
+	CDocFileOperation() = default;
 
 	//ロック
 	bool _ToDoLock() const;
@@ -77,8 +79,6 @@ public:
 	void FileCloseOpen(				//!< 閉じて開く	// 2006.12.30 ryoji
 		const SLoadInfo& sLoadInfo = SLoadInfo(L"", CODE_AUTODETECT, false)
 	);
-
-private:
-	CEditDoc* m_pcDocRef;
 };
+
 #endif /* SAKURA_CDOCFILEOPERATION_EE1C0546_8985_4FB1_941F_3BCC29BB3997_H_ */

--- a/sakura_core/doc/CDocListener.cpp
+++ b/sakura_core/doc/CDocListener.cpp
@@ -158,3 +158,12 @@ void CProgressSubject::NotifyProgress(int nPer)
 		GetListener(i)->OnProgress(nPer);
 	}
 }
+
+/*!
+ * コンストラクタ
+ */
+CDocRefClient::CDocRefClient()
+{
+	// ドキュメント参照を初期化する
+	m_pcDocRef = CEditDoc::getInstance();
+};

--- a/sakura_core/doc/CDocListener.h
+++ b/sakura_core/doc/CDocListener.h
@@ -214,4 +214,22 @@ class CFlowInterruption : public std::exception{
 public:
 	const char* what() const throw(){ return "CFlowInterruption"; }
 };
+
+/*!
+ * ドキュメントを参照するクラスの基底クラス
+ *
+ * コンストラクタでメンバー変数にドキュメント参照を取得する。
+ * CEditDocの構築を開始する前にインスタンス化しようとすると失敗する。
+ *
+ * 将来的には廃止すべき。
+ * m_pcDocRefの直接参照は控え、グローバル関数を利用すること。
+ */
+struct CDocRefClient
+{
+	//! ドキュメント参照
+	CEditDoc* m_pcDocRef;
+
+	CDocRefClient();
+};
+
 #endif /* SAKURA_CDOCLISTENER_BEF5B814_A5B8_4D07_9B2F_009A5CB29B2F_H_ */

--- a/sakura_core/doc/CDocOutline.h
+++ b/sakura_core/doc/CDocOutline.h
@@ -27,14 +27,20 @@
 #define SAKURA_CDOCOUTLINE_BDF55702_D938_432D_99F2_BF0F98A7C5FE_H_
 #pragma once
 
-class CEditDoc;
+#include "doc/CDocListener.h"
+
 class CFuncInfoArr;
 struct SOneRule;
 enum EOutlineType;
 
-class CDocOutline{
+/*!
+ * 編集中ドキュメントのアウトライン管理クラス
+ */
+class CDocOutline : private CDocRefClient
+{
 public:
-	CDocOutline(CEditDoc* pcDoc) : m_pcDocRef(pcDoc) { }
+	CDocOutline() = default;
+
 	void	MakeFuncList_C( CFuncInfoArr* pcFuncInfoArr,
 							EOutlineType& nOutlineType,
 						    const WCHAR* pszFileName,
@@ -56,7 +62,6 @@ public:
 	int		ReadRuleFile( const WCHAR* pszFilename, SOneRule* pcOneRule,
 						  int nMaxCount, bool& bRegex, std::wstring& title );	//!< ルールファイル読込 2002.04.01 YAZAKI
 	void	MakeFuncList_BookMark( CFuncInfoArr* );								//!< ブックマークリスト作成 //2001.12.03 hor
-private:
-	CEditDoc* m_pcDocRef;
 };
+
 #endif /* SAKURA_CDOCOUTLINE_BDF55702_D938_432D_99F2_BF0F98A7C5FE_H_ */

--- a/sakura_core/doc/CDocType.cpp
+++ b/sakura_core/doc/CDocType.cpp
@@ -34,9 +34,11 @@
 #include "view/figures/CFigureManager.h"
 #include "env/DllShareData.h"
 
+/*!
+ * コンストラクタ
+ */
 CDocType::CDocType(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
-	, m_pcDocRef(CEditDoc::getInstance())
 , m_nSettingType( 0 )			// Sep. 11, 2002 genta
 , m_typeConfig( GetDllShareData().m_TypeBasis )
 , m_nSettingTypeLocked( false )	//	設定値変更可能フラグ

--- a/sakura_core/doc/CDocType.h
+++ b/sakura_core/doc/CDocType.h
@@ -32,10 +32,14 @@
 #define SAKURA_CDOCTYPE_7009DED0_A784_49F3_B8C0_9A2559A9DAFA_H_
 #pragma once
 
+#include "doc/CDocListener.h"
 #include "types/CType.h" // CTypeConfig
 #include "env/CDocTypeManager.h"
 
-class CDocType : public ShareDataAccessorClient
+/*!
+ * 編集中ドキュメントの設定管理クラス
+ */
+class CDocType : public ShareDataAccessorClient, private CDocRefClient
 {
 public:
 	//生成と破棄
@@ -67,9 +71,9 @@ public:
 	void SetDocumentIcon();	//アイコンの設定	//Sep. 10, 2002 genta
 
 private:
-	CEditDoc*				m_pcDocRef;
 	CTypeConfig				m_nSettingType;
 	STypeConfig				m_typeConfig;
 	bool					m_nSettingTypeLocked;		//!< 文書種別の一時設定状態
 };
+
 #endif /* SAKURA_CDOCTYPE_7009DED0_A784_49F3_B8C0_9A2559A9DAFA_H_ */

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -170,7 +170,6 @@ CEditDoc::CEditDoc(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	, m_cDocEditor(GetShareDataAccessor())
 	, m_cDocType(GetShareDataAccessor())
 	, m_cAutoSaveAgent(GetShareDataAccessor())
-, m_cDocOutline(this)				// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_nCommandExecNum( 0 )			/* コマンド実行回数 */
 , m_hBackImg(NULL)
 {

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -167,7 +167,6 @@ static const EFunctionCode EIsModificationForbidden[] = {
 */
 CEditDoc::CEditDoc(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
-, m_cDocFileOperation(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 	, m_cDocEditor(GetShareDataAccessor())
 	, m_cDocType(GetShareDataAccessor())
 	, m_cAutoSaveAgent(GetShareDataAccessor())

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -167,7 +167,6 @@ static const EFunctionCode EIsModificationForbidden[] = {
 */
 CEditDoc::CEditDoc(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
-	, m_cDocFile(this)					// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 , m_cDocFileOperation(this)			// warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。
 	, m_cDocEditor(GetShareDataAccessor())
 	, m_cDocType(GetShareDataAccessor())


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)

## <!-- 必須 --> カテゴリ

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
* #13 
  のマージによりCEditDocクラス周辺の修正が可能になりました。
* CEditDocのコンストラクタに不審なコンパイラ警告メッセージがコピペされており、以前から気になっていました。
  `warning C4355: 'this' : ベース メンバー初期化子リストで使用されました。`

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
ふるまいは変わりません。
説明するのが苦痛なので省略します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
