### PR TITLE
ShareDataAccessorClientの改良

### DIFF
--- a/sakura_core/CAutoSaveAgent.cpp
+++ b/sakura_core/CAutoSaveAgent.cpp
@@ -69,8 +69,8 @@ void CAutoSaveAgent::CheckAutoSave()
 //
 void CAutoSaveAgent::ReloadAutoSaveParam()
 {
-	m_cPassiveTimer.SetInterval( GetDllShareData().m_Common.m_sBackup.GetAutoBackupInterval() );
-	m_cPassiveTimer.Enable( GetDllShareData().m_Common.m_sBackup.IsAutoBackupEnabled() );
+	m_cPassiveTimer.SetInterval( GetShareData()->m_Common.m_sBackup.GetAutoBackupInterval() );
+	m_cPassiveTimer.Enable( GetShareData()->m_Common.m_sBackup.IsAutoBackupEnabled() );
 }
 
 //----------------------------------------------------------

--- a/sakura_core/CHokanMgr.cpp
+++ b/sakura_core/CHokanMgr.cpp
@@ -119,9 +119,6 @@ int CHokanMgr::Search(
 {
 	CEditView* pcEditView = reinterpret_cast<CEditView*>(m_lParam);
 
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	/*
 	||  補完キーワードの検索
 	||

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -193,25 +193,19 @@ static LRESULT CALLBACK CControlTrayWndProc(
 
 /////////////////////////////////////////////////////////////////////////////
 // CControlTray
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-CControlTray::CControlTray()
-//	Apr. 24, 2001 genta
-: m_pcPropertyManager(NULL)
+CControlTray::CControlTray(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
+	, m_pcPropertyManager(NULL)
 , m_hInstance( NULL )
 , m_hWnd( NULL )
 , m_bCreatedTrayIcon( FALSE )	//トレイにアイコンを作った
 , m_nCurSearchKeySequence(-1)
 , m_uCreateTaskBarMsg( ::RegisterWindowMessage( TEXT("TaskbarCreated") ) )
 {
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	// アクセラレータテーブル作成
 	CreateAccelTbl();
 
 	m_bUseTrayMenu = false;
-
-	return;
 }
 
 CControlTray::~CControlTray()

--- a/sakura_core/_main/CControlTray.h
+++ b/sakura_core/_main/CControlTray.h
@@ -41,16 +41,14 @@ class CPropertyManager;
 /*!
 	タスクトレイアイコンの管理，タスクトレイメニューのアクション，
 	MRU、キー割り当て、共通設定、編集ウィンドウの管理など
-	
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-*/
-class CControlTray
+ */
+class CControlTray : private ShareDataAccessorClientWithCache
 {
 public:
 	/*
 	||  Constructors
 	*/
-	CControlTray();
+	explicit CControlTray(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
 	~CControlTray();
 
 	/*
@@ -121,7 +119,6 @@ private:
 	HWND			m_hWnd;
 	BOOL			m_bCreatedTrayIcon;		//!< トレイにアイコンを作った
 
-	DLLSHAREDATA*	m_pShareData;
 	CDlgGrep		m_cDlgGrep;				// Jul. 2, 2001 genta
 	int				m_nCurSearchKeySequence;
 

--- a/sakura_core/dlg/CDialog.h
+++ b/sakura_core/dlg/CDialog.h
@@ -214,20 +214,14 @@ protected:
  * 拡張版ダイアログの基底クラス
  *
  * 共有メモリにアクセスする機能を付加する。
- * 
- * @date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
  */
-class CSakuraDialog : public CDialog, public ShareDataAccessorClient
+class CSakuraDialog : public CDialog, public ShareDataAccessorClientWithCache
 {
 public:
-	DLLSHAREDATA* m_pShareData;
-
 	explicit CSakuraDialog(WORD idDialog_, std::shared_ptr<ShareDataAccessor> ShareDataAccessor_, std::shared_ptr<User32Dll> User32Dll_ = std::make_shared<User32Dll>())
 		: CDialog(idDialog_, std::move(User32Dll_))
-		, ShareDataAccessorClient(std::move(ShareDataAccessor_))
+		, ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	{
-		// 共有メモリのアドレスをメンバ変数に取得する
-		m_pShareData = &GetDllShareData();
 	}
 	~CSakuraDialog() override = default;
 

--- a/sakura_core/dlg/CDlgCompare.cpp
+++ b/sakura_core/dlg/CDlgCompare.cpp
@@ -253,7 +253,7 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
-	RECT rcDialog = GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog;
+	RECT rcDialog = GetShareData()->m_Common.m_sOthers.m_rcCompareDialog;
 	if( rcDialog.left != 0 ||
 		rcDialog.bottom != 0 ){
 		m_xPos = rcDialog.left;
@@ -268,7 +268,7 @@ BOOL CDlgCompare::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 BOOL CDlgCompare::OnDestroy( void )
 {
 	CDialog::OnDestroy();
-	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcCompareDialog;
+	RECT& rect = GetShareData()->m_Common.m_sOthers.m_rcCompareDialog;
 	rect.left = m_xPos;
 	rect.top = m_yPos;
 	rect.right = rect.left + m_nWidth;

--- a/sakura_core/dlg/CDlgDiff.cpp
+++ b/sakura_core/dlg/CDlgDiff.cpp
@@ -505,7 +505,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
-	RECT rcDialog = GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog;
+	RECT rcDialog = GetShareData()->m_Common.m_sOthers.m_rcDiffDialog;
 	if( rcDialog.left != 0 ||
 		rcDialog.bottom != 0 ){
 		m_xPos = rcDialog.left;
@@ -520,7 +520,7 @@ BOOL CDlgDiff::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 BOOL CDlgDiff::OnDestroy( void )
 {
 	CDialog::OnDestroy();
-	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcDiffDialog;
+	RECT& rect = GetShareData()->m_Common.m_sOthers.m_rcDiffDialog;
 	rect.left = m_xPos;
 	rect.top = m_yPos;
 	rect.right = rect.left + m_nWidth;

--- a/sakura_core/dlg/CDlgFavorite.cpp
+++ b/sakura_core/dlg/CDlgFavorite.cpp
@@ -401,7 +401,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 	CreateSizeBox();
 	CDialog::OnSize();
 
-	RECT rcDialog = GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog;
+	RECT rcDialog = GetShareData()->m_Common.m_sOthers.m_rcFavoriteDialog;
 	if( rcDialog.left != 0 ||
 		rcDialog.bottom != 0 ){
 		m_xPos = rcDialog.left;
@@ -498,7 +498,7 @@ BOOL CDlgFavorite::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 BOOL CDlgFavorite::OnDestroy( void )
 {
 	CDialog::OnDestroy();
-	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcFavoriteDialog;
+	RECT& rect = GetShareData()->m_Common.m_sOthers.m_rcFavoriteDialog;
 	rect.left = m_xPos;
 	rect.top = m_yPos;
 	rect.right = rect.left + m_nWidth;

--- a/sakura_core/dlg/CDlgOpenFile.cpp
+++ b/sakura_core/dlg/CDlgOpenFile.cpp
@@ -22,10 +22,22 @@
 #include "dlg/CDlgOpenFile.h"
 #include "env/DLLSHAREDATA.h"
 
-extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog();
-extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog();
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
 
-CDlgOpenFile::CDlgOpenFile() = default;
+/*!
+ * コンストラクタ
+ */
+CDlgOpenFile::CDlgOpenFile(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+{
+	if (GetShareData()->m_Common.m_sEdit.m_bVistaStyleFileDialog) {
+		m_pImpl = New_CDlgOpenFile_CommonItemDialog(GetShareDataAccessor());
+	}
+	else {
+		m_pImpl = New_CDlgOpenFile_CommonFileDialog(GetShareDataAccessor());
+	}
+}
 
 void CDlgOpenFile::Create(
 	HINSTANCE					hInstance,
@@ -35,12 +47,6 @@ void CDlgOpenFile::Create(
 	const std::vector<LPCWSTR>& vMRU,
 	const std::vector<LPCWSTR>& vOPENFOLDER
 ) {
-	if( GetDllShareData().m_Common.m_sEdit.m_bVistaStyleFileDialog ){
-		m_pImpl = New_CDlgOpenFile_CommonItemDialog();
-	}
-	else {
-		m_pImpl = New_CDlgOpenFile_CommonFileDialog();
-	}
 	m_pImpl->Create(hInstance, hwndParent, pszUserWildCard, pszDefaultPath, vMRU, vOPENFOLDER);
 }
 
@@ -69,6 +75,16 @@ inline bool CDlgOpenFile::DoModalSaveDlg(
 	bool bSimpleMode)
 {
 	return m_pImpl->DoModalSaveDlg(pSaveInfo, bSimpleMode);
+}
+
+/*!
+ * 実装がアイテムダイアログかどうかを返します。
+ *
+ * このメソッドはテスト用に作成したもので、機能としては不要です。
+ */
+bool CDlgOpenFile::IsItemDialog() const
+{
+	return m_pImpl->IsItemDialog();
 }
 
 /* static */

--- a/sakura_core/dlg/CDlgOpenFile.h
+++ b/sakura_core/dlg/CDlgOpenFile.h
@@ -22,6 +22,8 @@
 #define SAKURA_CDLGOPENFILE_8084B9DB_6463_4168_BA59_132EB2596AE7_H_
 #pragma once
 
+#include "env/ShareDataAccessor.hpp"
+
 #include <memory>
 #include <vector>
 #include "util/design_template.h"
@@ -81,16 +83,18 @@ public:
 		SSaveInfo*	pSaveInfo,
 		bool bSimpleMode
 	) = 0;
+
+	virtual bool IsItemDialog() const = 0;
 };
 
 
 /*!	ファイルオープンダイアログボックス
 */
-class CDlgOpenFile final : public IDlgOpenFile
+class CDlgOpenFile final : public IDlgOpenFile, private ShareDataAccessorClient
 {
 public:
 	//コンストラクタ・デストラクタ
-	CDlgOpenFile();
+	explicit CDlgOpenFile(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
 	~CDlgOpenFile() = default;
 
 	void Create(
@@ -109,6 +113,8 @@ public:
 		std::vector<std::wstring>* pFilenames,
 		bool bOptions = true) override;
 	bool DoModalSaveDlg(SSaveInfo*	pSaveInfo, bool bSimpleMode) override;
+
+	bool IsItemDialog() const override;
 
 	// 設定フォルダー相対ファイル選択(共有データ,ini位置依存)
 	static BOOL SelectFile(HWND parent, HWND hwndCtl, const WCHAR* filter,

--- a/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonFileDialog.cpp
@@ -61,9 +61,9 @@ static const DWORD p_helpids[] = {	//13100
 
 static int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit);
 
-struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
+struct CDlgOpenFile_CommonFileDialog final : public ShareDataAccessorClientWithCache, public IDlgOpenFile
 {
-	CDlgOpenFile_CommonFileDialog();
+	explicit CDlgOpenFile_CommonFileDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
 
 	void Create(
 		HINSTANCE					hInstance,
@@ -79,6 +79,8 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 	bool DoModalOpenDlg( SLoadInfo* pLoadInfo, std::vector<std::wstring>*, bool bOptions ) override;
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo, bool bSimpleMode ) override;
 
+	bool IsItemDialog() const override { return false; }
+
 	void DlgOpenFail(void);
 
 	void InitOfn( OPENFILENAME* ofn );
@@ -92,8 +94,6 @@ struct CDlgOpenFile_CommonFileDialog final : public IDlgOpenFile
 
 	HINSTANCE		m_hInstance;	/* アプリケーションインスタンスのハンドル */
 	HWND			m_hwndParent;	/* オーナーウィンドウのハンドル */
-
-	DLLSHAREDATA*	m_pShareData;
 
 	std::wstring	m_strDefaultWildCard{ L"*.*" };	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
@@ -647,13 +647,11 @@ int AddComboCodePages(HWND hdlg, HWND combo, int nSelCode, bool& bInit)
 /*! コンストラクタ
 	@date 2008.05.05 novice GetModuleHandle(NULL)→NULLに変更
 */
-CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
+CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
-
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
 
 	WCHAR	szFile[_MAX_PATH + 1];
 	WCHAR	szDrive[_MAX_DRIVE];
@@ -665,8 +663,6 @@ CDlgOpenFile_CommonFileDialog::CDlgOpenFile_CommonFileDialog()
 	_wsplitpath( szFile, szDrive, szDir, NULL, NULL );
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
-
-	return;
 }
 
 /* 初期化 */
@@ -1225,8 +1221,7 @@ bool CDlgOpenFile_CommonFileDialog::GetSaveFileNameRecover( OPENFILENAME* ofn )
 	return bRet!=FALSE;
 }
 
-std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog()
+std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 {
-	std::shared_ptr<IDlgOpenFile> ret(new CDlgOpenFile_CommonFileDialog());
-	return ret;
+	return std::make_shared<CDlgOpenFile_CommonFileDialog>(std::move(ShareDataAccessor_));
 }

--- a/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
+++ b/sakura_core/dlg/CDlgOpenFile_CommonItemDialog.cpp
@@ -37,12 +37,12 @@
 #include "String_define.h"
 
 struct CDlgOpenFile_CommonItemDialog final
-	:
-	public IDlgOpenFile,
+	: private ShareDataAccessorClientWithCache
+	, public IDlgOpenFile,
 	private IFileDialogEvents,
 	private IFileDialogControlEvents
 {
-	CDlgOpenFile_CommonItemDialog();
+	explicit CDlgOpenFile_CommonItemDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
 
 	void Create(
 		HINSTANCE					hInstance,
@@ -61,6 +61,8 @@ struct CDlgOpenFile_CommonItemDialog final
 	bool DoModalSaveDlg( SSaveInfo*	pSaveInfo,
 						 bool bSimpleMode ) override;
 
+	bool IsItemDialog() const override { return true; }
+
 	bool DoModalOpenDlgImpl0( bool bAllowMultiSelect,
 							  std::vector<std::wstring>* pFileNames,
 							  LPCWSTR fileName,
@@ -76,8 +78,6 @@ struct CDlgOpenFile_CommonItemDialog final
 
 	HINSTANCE		m_hInstance;	/* アプリケーションインスタンスのハンドル */
 	HWND			m_hwndParent;	/* オーナーウィンドウのハンドル */
-
-	DLLSHAREDATA*	m_pShareData;
 
 	std::wstring	m_strDefaultWildCard{ L"*.*" };	/* 「開く」での最初のワイルドカード（保存時の拡張子補完でも使用される） */
 	SFilePath		m_szInitialDir;			/* 「開く」での初期ディレクトリ */
@@ -399,13 +399,11 @@ enum CtrlId {
 	COMBO_OPENFOLDER,
 };
 
-CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
+CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	m_hInstance = NULL;		/* アプリケーションインスタンスのハンドル */
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
-
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
 
 	WCHAR	szFile[_MAX_PATH + 1];
 	WCHAR	szDrive[_MAX_DRIVE];
@@ -417,9 +415,6 @@ CDlgOpenFile_CommonItemDialog::CDlgOpenFile_CommonItemDialog()
 	_wsplitpath( szFile, szDrive, szDir, NULL, NULL );
 	wcscpy( m_szInitialDir, szDrive );
 	wcscat( m_szInitialDir, szDir );
-
-
-	return;
 }
 
 /* 初期化 */
@@ -940,8 +935,7 @@ int CDlgOpenFile_CommonItemDialog::AddComboCodePages( int nSelCode )
 	return nSel;
 }
 
-std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog()
+std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 {
-	std::shared_ptr<IDlgOpenFile> ret(new CDlgOpenFile_CommonItemDialog());
-	return ret;
+	return std::make_shared<CDlgOpenFile_CommonItemDialog>(std::move(ShareDataAccessor_));
 }

--- a/sakura_core/dlg/CDlgTagJumpList.cpp
+++ b/sakura_core/dlg/CDlgTagJumpList.cpp
@@ -447,7 +447,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 		GetItemClientRect( anchorList[i].id, m_rcItems[i] );
 	}
 
-	RECT rcDialog = GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog;
+	RECT rcDialog = GetShareData()->m_Common.m_sOthers.m_rcTagJumpDialog;
 	if( rcDialog.left != 0 ||
 		rcDialog.bottom != 0 ){
 		m_xPos = rcDialog.left;
@@ -541,7 +541,7 @@ BOOL CDlgTagJumpList::OnInitDialog( HWND hwndDlg, WPARAM wParam, LPARAM lParam )
 BOOL CDlgTagJumpList::OnDestroy( void )
 {
 	CDialog::OnDestroy();
-	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcTagJumpDialog;
+	RECT& rect = GetShareData()->m_Common.m_sOthers.m_rcTagJumpDialog;
 	rect.left = m_xPos;
 	rect.top = m_yPos;
 	rect.right = rect.left + m_nWidth;

--- a/sakura_core/dlg/CDlgWindowList.cpp
+++ b/sakura_core/dlg/CDlgWindowList.cpp
@@ -205,7 +205,7 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 		GetItemClientRect(anchorList[i].id, m_rcItems[i]);
 	}
 
-	RECT rcDialog = GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog;
+	RECT rcDialog = GetShareData()->m_Common.m_sOthers.m_rcWindowListDialog;
 	if (rcDialog.left != 0 || rcDialog.bottom != 0) {
 		m_xPos = rcDialog.left;
 		m_yPos = rcDialog.top;
@@ -239,7 +239,7 @@ BOOL CDlgWindowList::OnInitDialog(HWND hwndDlg, WPARAM wParam, LPARAM lParam)
 BOOL CDlgWindowList::OnDestroy( void )
 {
 	CDialog::OnDestroy();
-	RECT& rect = GetDllShareData().m_Common.m_sOthers.m_rcWindowListDialog;
+	RECT& rect = GetShareData()->m_Common.m_sOthers.m_rcWindowListDialog;
 	rect.left = m_xPos;
 	rect.top = m_yPos;
 	rect.right = rect.left + m_nWidth;

--- a/sakura_core/doc/CDocEditor.cpp
+++ b/sakura_core/doc/CDocEditor.cpp
@@ -47,7 +47,7 @@ CDocEditor::CDocEditor(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 , m_bIsDocModified( false )	/* 変更フラグ */ // Jan. 22, 2002 genta 型変更
 {
 	//	Oct. 2, 2005 genta 挿入モード
-	this->SetInsMode( GetDllShareData().m_Common.m_sGeneral.m_bIsINSMode );
+	this->SetInsMode( GetShareData()->m_Common.m_sGeneral.m_bIsINSMode );
 }
 
 /*! 変更フラグの設定

--- a/sakura_core/doc/CDocType.cpp
+++ b/sakura_core/doc/CDocType.cpp
@@ -40,7 +40,7 @@
 CDocType::CDocType(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
 , m_nSettingType( 0 )			// Sep. 11, 2002 genta
-, m_typeConfig( GetDllShareData().m_TypeBasis )
+	, m_typeConfig( GetShareData()->m_TypeBasis )
 , m_nSettingTypeLocked( false )	//	設定値変更可能フラグ
 {
 }

--- a/sakura_core/doc/CEditDoc.cpp
+++ b/sakura_core/doc/CEditDoc.cpp
@@ -216,7 +216,7 @@ CEditDoc::CEditDoc(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 	m_cDocEditor.m_cNewLineCode = ref.m_encoding.m_eDefaultEoltype;
 
 	// 排他制御オプションを初期化
-	m_cDocFile.SetShareMode( GetDllShareData().m_Common.m_sFile.m_nFileShareMode );
+	m_cDocFile.SetShareMode( GetShareData()->m_Common.m_sFile.m_nFileShareMode );
 
 	m_cLayoutMgr.SetLayoutInfo(true, false, m_cDocType.GetDocumentAttribute(),
 		m_cLayoutMgr.GetTabSpaceKetas(), m_cLayoutMgr.m_tsvInfo.m_nTsvMode,

--- a/sakura_core/env/CDocTypeManager.h
+++ b/sakura_core/env/CDocTypeManager.h
@@ -33,15 +33,16 @@
 #include "types/CType.h"
 
 struct DLLSHAREDATA;
-DLLSHAREDATA& GetDllShareData();
 
 //! ドキュメントタイプ管理
-class CDocTypeManager{
+class CDocTypeManager : private ShareDataAccessorClientWithCache
+{
 public:
-	CDocTypeManager()
+	explicit CDocTypeManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>())
+		: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	{
-		m_pShareData = &GetDllShareData();
 	}
+
 	CTypeConfig GetDocumentTypeOfPath( const WCHAR* pszFilePath );	/* ファイルパスを渡して、ドキュメントタイプ（数値）を取得する */
 	CTypeConfig GetDocumentTypeOfExt( const WCHAR* pszExt );		/* 拡張子を渡して、ドキュメントタイプ（数値）を取得する */
 	CTypeConfig GetDocumentTypeOfId( int id );
@@ -58,8 +59,6 @@ public:
 
 	static const WCHAR* m_typeExtSeps;			// タイプ別拡張子の区切り文字
 	static const WCHAR* m_typeExtWildcards;		// タイプ別拡張子のワイルドカード
-
-private:
-	DLLSHAREDATA* m_pShareData;
 };
+
 #endif /* SAKURA_CDOCTYPEMANAGER_ACE5AE64_5C6A_4A70_BACF_99F9A448360D_H_ */

--- a/sakura_core/env/CFileNameManager.h
+++ b/sakura_core/env/CFileNameManager.h
@@ -30,21 +30,22 @@
 #define SAKURA_CFILENAMEMANAGER_2B89B426_470E_40D6_B62E_5321E383ECD6_H_
 #pragma once
 
+#include "env/ShareDataAccessor.hpp"
+
+#include "config/maxdata.h"
+#include "util/design_template.h"
+
 #include <string_view>
 
-#include "util/design_template.h"
-#include "config/maxdata.h"
-
-struct DLLSHAREDATA;
 struct EditInfo;
-DLLSHAREDATA& GetDllShareData();
 
 //!ファイル名管理
-class CFileNameManager : public TSingleton<CFileNameManager>{
+class CFileNameManager : public TSingleton<CFileNameManager>, private ShareDataAccessorClientWithCache
+{
 	friend class TSingleton<CFileNameManager>;
-	CFileNameManager()
+	explicit CFileNameManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>())
+		: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	{
-		m_pShareData = &GetDllShareData();
 		m_nTransformFileNameCount = -1;
 	}
 
@@ -78,11 +79,10 @@ public:
 	static WCHAR GetAccessKeyByIndex(int index, bool bZeroOrigin);
 
 private:
-	DLLSHAREDATA* m_pShareData;
-
 	// ファイル名簡易表示用キャッシュ
 	int		m_nTransformFileNameCount; // 有効数
 	WCHAR	m_szTransformFileNameFromExp[MAX_TRANSFORM_FILENAME][_MAX_PATH];
 	int		m_nTransformFileNameOrgId[MAX_TRANSFORM_FILENAME];
 };
+
 #endif /* SAKURA_CFILENAMEMANAGER_2B89B426_470E_40D6_B62E_5321E383ECD6_H_ */

--- a/sakura_core/env/CFormatManager.cpp
+++ b/sakura_core/env/CFormatManager.cpp
@@ -28,10 +28,17 @@
 */
 
 #include "StdAfx.h"
-#include "DLLSHAREDATA.h"
+#include "env/CFormatManager.h"
 
-#include "CFormatManager.h"
 #include "CSelectLang.h"
+
+/*!
+ * コンストラクタ
+ */
+CFormatManager::CFormatManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
+{
+}
 
 /*! 日付をフォーマット
 	systime：時刻データ

--- a/sakura_core/env/CFormatManager.h
+++ b/sakura_core/env/CFormatManager.h
@@ -30,16 +30,15 @@
 #define SAKURA_CFORMATMANAGER_4161FE80_FFA1_4619_BD0A_74FF4F59BDDA_H_
 #pragma once
 
-struct DLLSHAREDATA;
-DLLSHAREDATA& GetDllShareData();
+#include "env/ShareDataAccessor.hpp"
+#include "env/DLLSHAREDATA.h"
 
 //!書式管理
-class CFormatManager{
+class CFormatManager : private ShareDataAccessorClientWithCache
+{
 public:
-	CFormatManager()
-	{
-		m_pShareData = &GetDllShareData();
-	}
+	explicit CFormatManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
+
 	//書式 //@@@ 2002.2.9 YAZAKI
 	// 共有DLLSHAREDATA依存
 	const WCHAR* MyGetDateFormat( const SYSTEMTIME& systime, WCHAR* pszDest, int nDestLen );
@@ -48,7 +47,6 @@ public:
 	// 共有DLLSHAREDATA非依存
 	const WCHAR* MyGetDateFormat( const SYSTEMTIME& systime, WCHAR* pszDest, int nDestLen, int nDateFormatType, const WCHAR* szDateFormat );
 	const WCHAR* MyGetTimeFormat( const SYSTEMTIME& systime, WCHAR* pszDest, int nDestLen, int nTimeFormatType, const WCHAR* szTimeFormat );
-private:
-	DLLSHAREDATA* m_pShareData;
 };
+
 #endif /* SAKURA_CFORMATMANAGER_4161FE80_FFA1_4619_BD0A_74FF4F59BDDA_H_ */

--- a/sakura_core/env/CHelpManager.cpp
+++ b/sakura_core/env/CHelpManager.cpp
@@ -25,13 +25,17 @@
 
 		3. This notice may not be removed or altered from any source
 		   distribution.
-*/
-
+ */
 #include "StdAfx.h"
-#include "DLLSHAREDATA.h"
+#include "env/CHelpManager.h"
 
-#include "CHelpManager.h"
-#include "env/CDocTypeManager.h"
+/*!
+ * コンストラクタ
+ */
+CHelpManager::CHelpManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
+{
+}
 
 /*!	外部Winヘルプが設定されているか確認。
 */

--- a/sakura_core/env/CHelpManager.h
+++ b/sakura_core/env/CHelpManager.h
@@ -30,23 +30,21 @@
 #define SAKURA_CHELPMANAGER_57445D73_99E9_4B85_A905_47685753D1DF_H_
 #pragma once
 
-struct DLLSHAREDATA;
-DLLSHAREDATA& GetDllShareData();
+#include "env/ShareDataAccessor.hpp"
+#include "env/DLLSHAREDATA.h"
 
 //!ヘルプ管理
-class CHelpManager{
+class CHelpManager : private ShareDataAccessorClientWithCache
+{
 public:
-	CHelpManager()
-	{
-		m_pShareData = &GetDllShareData();
-	}
+	explicit CHelpManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
+
 	//ヘルプ関連	//@@@ 2002.2.3 YAZAKI
 	bool			ExtWinHelpIsSet( const STypeConfig* pType = NULL );		//	タイプがnTypeのときに、外部ヘルプが設定されているか。
 	const WCHAR*	GetExtWinHelp( const STypeConfig* pType = NULL );		//	タイプがnTypeのときの、外部ヘルプファイル名を取得。
 	bool			ExtHTMLHelpIsSet( const STypeConfig* pType = NULL );	//	タイプがnTypeのときに、外部HTMLヘルプが設定されているか。
 	const WCHAR*	GetExtHTMLHelp( const STypeConfig* pType = NULL );		//	タイプがnTypeのときの、外部HTMLヘルプファイル名を取得。
 	bool			HTMLHelpIsSingle( const STypeConfig* pType = NULL );	//	タイプがnTypeのときの、外部HTMLヘルプ「ビューアを複数起動しない」がONかを取得。
-private:
-	DLLSHAREDATA* m_pShareData;
 };
+
 #endif /* SAKURA_CHELPMANAGER_57445D73_99E9_4B85_A905_47685753D1DF_H_ */

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -30,6 +30,8 @@
 #define SAKURA_CSEARCHKEYWORDMANAGER_AFD28203_4738_46B7_9A7F_E758A94DB290_H_
 #pragma once
 
+#include "env/ShareDataAccessor.hpp"
+
 //共有メモリ内構造体
 struct SShare_SearchKeywords{
 	// -- -- 検索キー -- -- //
@@ -41,16 +43,15 @@ struct SShare_SearchKeywords{
 	StaticVector< StaticString<WCHAR, MAX_EXCLUDE_PATH>, MAX_EXCLUDEFOLDER, const WCHAR*>	m_aExcludeFolders;
 };
 
-struct DLLSHAREDATA;
-DLLSHAREDATA& GetDllShareData();
-
 //! 検索キーワード管理
-class CSearchKeywordManager{
+class CSearchKeywordManager : private ShareDataAccessorClientWithCache
+{
 public:
-	CSearchKeywordManager()
+	explicit CSearchKeywordManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>())
+		: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	{
-		m_pShareData = &GetDllShareData();
 	}
+
 	//@@@ 2002.2.2 YAZAKI
 	void		AddToSearchKeyArr( const wchar_t* pszSearchKey );	//	m_aSearchKeysにpszSearchKeyを追加する
 	void		AddToReplaceKeyArr( const wchar_t* pszReplaceKey );	//	m_aReplaceKeysにpszReplaceKeyを追加する
@@ -58,7 +59,6 @@ public:
 	void		AddToGrepFolderArr( const WCHAR* pszGrepFolder );	//	m_aGrepFolders にpszGrepFolder を追加する
 	void		AddToExcludeFileArr( const WCHAR* pszExcludeFile );		//	m_aExcludeFiles に pszExcludeFile を追加する
 	void		AddToExcludeFolderArr( const WCHAR* pszExcludeFolder );	//	m_aExcludeFolders に pszExcludeFolder を追加する
-private:
-	DLLSHAREDATA* m_pShareData;
 };
+
 #endif /* SAKURA_CSEARCHKEYWORDMANAGER_AFD28203_4738_46B7_9A7F_E758A94DB290_H_ */

--- a/sakura_core/env/CTagJumpManager.h
+++ b/sakura_core/env/CTagJumpManager.h
@@ -58,19 +58,17 @@ struct SShare_TagJump{
 	BOOL				m_bTagJumpPartialMatch;				//!< 文字列の途中にマッチ
 };
 
-struct DLLSHAREDATA;
-DLLSHAREDATA& GetDllShareData();
-
-class CTagJumpManager{
+class CTagJumpManager : private ShareDataAccessorClientWithCache
+{
 public:
-	CTagJumpManager()
+	explicit CTagJumpManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>())
+		: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	{
-		m_pShareData = &GetDllShareData();
 	}
+
 	//タグジャンプ関連	// 2004/06/21 novice タグジャンプ機能追加
 	void PushTagJump(const TagJump * pTagJump);		//!< タグジャンプ情報の保存
 	bool PopTagJump(TagJump *pTagJump);				//!< タグジャンプ情報の参照
-private:
-	DLLSHAREDATA* m_pShareData;
 };
+
 #endif /* SAKURA_CTAGJUMPMANAGER_487A43FC_EB78_44CF_B1E4_6FD78EF1F35A_H_ */

--- a/sakura_core/env/ShareDataAccessor.hpp
+++ b/sakura_core/env/ShareDataAccessor.hpp
@@ -40,9 +40,6 @@ struct ShareDataAccessor
 
 /*!
  * 共有メモリに依存するクラスの基底クラス
- *
- * コンストラクタ内でGetDllShareData()を呼び出してクラッシュするクラスを
- * テスト可能にするために用意した基底クラスです。
  */
 class ShareDataAccessorClient
 {
@@ -74,5 +71,26 @@ protected:
 	DLLSHAREDATA* GetShareData() const
 	{
 		return _ShareDataAccessor->GetShareData();
+	}
+};
+
+/*!
+ * 構築時に共有メモリをキャッシュするクラスの基底クラス
+ *
+ * コンストラクタ内で共有メモリにアクセスしてクラッシュするクラスを
+ * テスト可能にするために用意した基底クラスです。
+ *
+ * @date 2002/02/17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
+ */
+class ShareDataAccessorClientWithCache : public ShareDataAccessorClient
+{
+public:
+	DLLSHAREDATA* m_pShareData;
+
+	explicit ShareDataAccessorClientWithCache(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+		: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	{
+		/* 共有データ構造体のアドレスを返す */
+		m_pShareData = GetShareData();
 	}
 };

--- a/sakura_core/env/ShareDataAccessor.hpp
+++ b/sakura_core/env/ShareDataAccessor.hpp
@@ -58,14 +58,6 @@ protected:
 	}
 
 	/*!
-	 * 共有メモリ構造体への参照を取得します。
-	 */
-	DLLSHAREDATA& GetDllShareData() const
-	{
-		return *GetShareData();
-	}
-
-	/*!
 	 * 共有メモリ構造体のアドレスを取得します。
 	 */
 	DLLSHAREDATA* GetShareData() const

--- a/sakura_core/func/CFuncKeyWnd.cpp
+++ b/sakura_core/func/CFuncKeyWnd.cpp
@@ -51,16 +51,16 @@ LRESULT CALLBACK CFuncKeyWndProc(
 }
 ***/
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
+/*!
+ * コンストラクタ
+ */
 CFuncKeyWnd::CFuncKeyWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 : CWnd(L"::CFuncKeyWnd")
-	, ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	, ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	int		i;
 	LOGFONT	lf;
 	m_pcEditDoc = NULL;
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
 	m_nCurrentKeyState = -1;
 	for( i = 0; i < _countof(m_szFuncNameArr); ++i ){
 		m_szFuncNameArr[i][0] = LTEXT('\0');

--- a/sakura_core/func/CFuncKeyWnd.h
+++ b/sakura_core/func/CFuncKeyWnd.h
@@ -24,8 +24,7 @@ struct DLLSHAREDATA;
 class CEditDoc; // 2002/2/10 aroka
 
 //! ファンクションキーウィンドウ
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-class CFuncKeyWnd final : public CWnd, public ShareDataAccessorClient
+class CFuncKeyWnd final : public CWnd, private ShareDataAccessorClientWithCache
 {
 public:
 	/*
@@ -47,7 +46,6 @@ public:
 private:
 	// 20060126 aroka すべてPrivateにして、初期化順序に合わせて並べ替え
 	CEditDoc*		m_pcEditDoc;
-	DLLSHAREDATA*	m_pShareData;
 	int				m_nCurrentKeyState;
 	WCHAR			m_szFuncNameArr[12][256];
 	HWND			m_hwndButtonArr[12];
@@ -72,4 +70,5 @@ protected:
 	LRESULT OnSize(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;// WM_SIZE処理
 	LRESULT OnDestroy(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) override;// WM_DESTROY処理
 };
+
 #endif /* SAKURA_CFUNCKEYWND_2EB0FD88_ABBB_4280_BEEA_46E8468E4550_H_ */

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -486,14 +486,12 @@ MacroFuncInfo CSMacroMgr::m_MacroFuncInfoArr[] =
 };
 
 /*!
-	@date 2002.02.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-	@date 2002.04.29 genta オブジェクトの実体は実行時まで生成しない。
-*/
-CSMacroMgr::CSMacroMgr()
+ * コンストラクタ
+ */
+CSMacroMgr::CSMacroMgr(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	MY_RUNNINGTIMER( cRunningTimer, L"CSMacroMgr::CSMacroMgr" );
-	
-	m_pShareData = &GetDllShareData();
 	
 	CPPAMacroMgr::declare();
 	CKeyMacroMgr::declare();

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -71,10 +71,8 @@ typedef MacroFuncInfo* MacroFuncInfoArray;
 
 /*-----------------------------------------------------------------------
 クラスの宣言
-
-@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 -----------------------------------------------------------------------*/
-class CSMacroMgr
+class CSMacroMgr : private ShareDataAccessorClientWithCache
 {
 	//	データの型宣言
 	CMacroManagerBase* m_cSavedKeyMacro[MAX_CUSTMACRO];	//	キーマクロをカスタムメニューの数だけ管理
@@ -90,7 +88,7 @@ public:
 	/*
 	||  Constructors
 	*/
-	CSMacroMgr();
+	explicit CSMacroMgr(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
 	~CSMacroMgr();
 
 	/*
@@ -168,7 +166,6 @@ public:
 	CMacroManagerBase* SetTempMacro( CMacroManagerBase *newMacro );
 
 private:
-	DLLSHAREDATA*	m_pShareData;
 	CMacroManagerBase** Idx2Ptr(int idx);
 
 	/*!	実行中マクロのインデックス番号 (INVALID_MACRO_IDX:無効)
@@ -184,4 +181,5 @@ public:
 
 	DISALLOW_COPY_AND_ASSIGN(CSMacroMgr);
 };
+
 #endif /* SAKURA_CSMACROMGR_9F01D007_5F13_4963_887B_B37E861070DA_H_ */

--- a/sakura_core/plugin/CJackManager.cpp
+++ b/sakura_core/plugin/CJackManager.cpp
@@ -32,7 +32,8 @@
 #include "typeprop/CPropTypes.h"
 
 //コンストラクタ
-CJackManager::CJackManager()
+CJackManager::CJackManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	int i;
 
@@ -58,8 +59,6 @@ CJackManager::CJackManager()
 		{ PP_COMPLEMENT				, L"Complement"			},
 		{ PP_COMPLEMENTGLOBAL		, L"ComplementGlobal"	},
 	};
-
-	m_pShareData = &GetDllShareData();
 
 	m_Jacks.reserve( PP_BUILTIN_JACK_COUNT );
 	for( i=0; i<PP_BUILTIN_JACK_COUNT; i++ ){

--- a/sakura_core/plugin/CJackManager.h
+++ b/sakura_core/plugin/CJackManager.h
@@ -74,9 +74,10 @@ enum ERegisterPlugResult {
 };
 
 //ジャック管理クラス
-class CJackManager final : public TSingleton<CJackManager>{
+class CJackManager final : public TSingleton<CJackManager>, private ShareDataAccessorClientWithCache
+{
 	friend class TSingleton<CJackManager>;
-	CJackManager();
+	explicit CJackManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
 
 	typedef std::wstring wstring;
 
@@ -101,7 +102,7 @@ public:
 
 	//メンバ変数
 private:
-	DLLSHAREDATA* m_pShareData;
 	std::vector<JackDef> m_Jacks;	//ジャック定義の一覧
 };
+
 #endif /* SAKURA_CJACKMANAGER_99C6FE17_62C7_45E8_82F2_C36441FF809C_H_ */

--- a/sakura_core/prop/CPropCommon.cpp
+++ b/sakura_core/prop/CPropCommon.cpp
@@ -127,9 +127,8 @@ INT_PTR CPropCommon::DlgProc2(
 	}
 }
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 CPropCommon::CPropCommon(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
-	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	{
 		assert( sizeof(CPropGeneral)   - sizeof(CPropCommon) == 0 );
@@ -152,18 +151,11 @@ CPropCommon::CPropCommon(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 		assert( sizeof(CPropPlugin)    - sizeof(CPropCommon) == 0 );
 	}
 
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	m_hwndParent = NULL;	/* オーナーウィンドウのハンドル */
 	m_hwndThis  = NULL;		/* このダイアログのハンドル */
 	m_nPageNum = ID_PROPCOM_PAGENUM_GENERAL;
 	m_nKeywordSet1 = -1;
-
-	return;
 }
-
-CPropCommon::~CPropCommon() = default;
 
 /* 初期化 */
 //@@@ 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。

--- a/sakura_core/prop/CPropCommon.h
+++ b/sakura_core/prop/CPropCommon.h
@@ -83,17 +83,16 @@ enum PropComSheetOrder {
 
 	1つのダイアログボックスに複数のプロパティページが入った構造に
 	なっており、Dialog procedureとEvent Dispatcherがページごとにある．
-
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-*/
-class CPropCommon : public ShareDataAccessorClient
+ */
+class CPropCommon : public ShareDataAccessorClientWithCache
 {
 public:
 	/*
 	||  Constructors
 	*/
 	explicit CPropCommon(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
-	~CPropCommon();
+	~CPropCommon() = default;
+
 	//	Sep. 29, 2001 genta マクロクラスを渡すように;
 //@@@ 2002.01.03 YAZAKI m_tbMyButtonなどをCShareDataからCMenuDrawerへ移動したことによる修正。
 	void Create( HWND hwndParent, CImageListMgr* pcIcons, CMenuDrawer* pMenuDrawer );	/* 初期化 */
@@ -118,7 +117,6 @@ public:
 	HWND				m_hwndParent;	/* オーナーウィンドウのハンドル */
 	HWND				m_hwndThis;		/* このダイアログのハンドル */
 	PropComSheetOrder	m_nPageNum;
-	DLLSHAREDATA*		m_pShareData;
 	int					m_nKeywordSet1;
 	//	Oct. 16, 2000 genta
 	CImageListMgr*	m_pcIcons;	//	Image List

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -28,21 +28,13 @@
 #include "util/string_ex2.h"
 #include "util/window.h"
 
-/*!	コンストラクタ
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-*/
+/*!
+ * コンストラクタ
+ */
 CMRUFile::CMRUFile(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
-	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	, m_cRecentFile(GetShareDataAccessor())
 {
-	//	初期化。
-	m_pShareData = &GetDllShareData();
-}
-
-/*	デストラクタ	*/
-CMRUFile::~CMRUFile()
-{
-	m_cRecentFile.Terminate();
 }
 
 /*!

--- a/sakura_core/recent/CMRUFile.h
+++ b/sakura_core/recent/CMRUFile.h
@@ -37,15 +37,14 @@
 #define SAKURA_CMRUFILE_41099ADB_562E_457B_873D_8F81AC958AC2_H_
 #pragma once
 
-#include <Windows.h> /// BOOL,HMENU // 2002/2/10 aroka
-#include <vector>
 #include "recent/CRecentFile.h"
+
+#include <vector>
 
 struct EditInfo; // 2004.04.11 genta パラメータ内のstructを削除するため．doxygen対策
 class CMenuDrawer;
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-class CMRUFile : public ShareDataAccessorClient
+class CMRUFile : private ShareDataAccessorClientWithCache
 {
 	using Me = CMRUFile;
 
@@ -56,7 +55,7 @@ public:
 	Me& operator = (const Me&) = delete;
 	CMRUFile(Me&&) noexcept = delete;
 	Me& operator = (Me&&) noexcept = delete;
-	~CMRUFile();
+	~CMRUFile() = default;
 
 	//	メニューを取得する
 	HMENU CreateMenu( CMenuDrawer* pCMenuDrawer ) const;	//	うーん。pCMenuDrawerが必要なくなるといいなぁ。
@@ -74,11 +73,8 @@ public:
 	bool GetEditInfo( const WCHAR* pszPath, EditInfo* pfi ) const;	//	ファイル名で指定したEditInfo（情報をまるごと）
 	void Add( EditInfo* pEditInfo );		//	*pEditInfoを追加する。
 
-protected:
-	//	共有メモリアクセス用。
-	struct DLLSHAREDATA*	m_pShareData;		//	共有メモリを参照するよ。
-
 private:
 	CRecentFile	m_cRecentFile;	//履歴	//@@@ 2003.04.08 MIK
 };
+
 #endif /* SAKURA_CMRUFILE_41099ADB_562E_457B_873D_8F81AC958AC2_H_ */

--- a/sakura_core/recent/CMRUFolder.cpp
+++ b/sakura_core/recent/CMRUFolder.cpp
@@ -23,22 +23,13 @@
 #include "util/string_ex2.h"
 #include "util/window.h"
 
-/*!	コンストラクタ
-
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-*/
+/*!
+ * コンストラクタ
+ */
 CMRUFolder::CMRUFolder(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
-	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	, m_cRecentFolder(GetShareDataAccessor())
 {
-	//	初期化。
-	m_pShareData = &GetDllShareData();
-}
-
-/*	デストラクタ	*/
-CMRUFolder::~CMRUFolder()
-{
-	m_cRecentFolder.Terminate();
 }
 
 /*!

--- a/sakura_core/recent/CMRUFolder.h
+++ b/sakura_core/recent/CMRUFolder.h
@@ -36,13 +36,11 @@
 #define SAKURA_CMRUFOLDER_32D69CDD_037F_4DE1_961E_B730F56F4189_H_
 #pragma once
 
-#include <Windows.h> /// BOOL,HMENU // 2002/2/10 aroka
 #include "recent/CRecentFolder.h"
 
 class CMenuDrawer;
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-class CMRUFolder : public ShareDataAccessorClient
+class CMRUFolder : private ShareDataAccessorClientWithCache
 {
 	using Me = CMRUFolder;
 
@@ -53,7 +51,7 @@ public:
 	Me& operator = (const Me&) = delete;
 	CMRUFolder(Me&&) noexcept = delete;
 	Me& operator = (Me&&) noexcept = delete;
-	~CMRUFolder();
+	~CMRUFolder() = default;
 
 	//	メニューを取得する
 	HMENU CreateMenu( CMenuDrawer* pCMenuDrawer ) const;	//	うーん。pCMenuDrawerが必要なくなるといいなぁ。
@@ -70,11 +68,8 @@ public:
 	void Add( const WCHAR* pszFolder );	//	pszFolderを追加する。
 	const WCHAR* GetPath(int num) const;
 
-protected:
-	//	共有メモリアクセス用。
-	struct DLLSHAREDATA*	m_pShareData;			//	共有メモリを参照するよ。
-
 private:
 	CRecentFolder	m_cRecentFolder;	//履歴	//@@@ 2003.04.08 MIK
 };
+
 #endif /* SAKURA_CMRUFOLDER_32D69CDD_037F_4DE1_961E_B730F56F4189_H_ */

--- a/sakura_core/typeprop/CImpExpManager.h
+++ b/sakura_core/typeprop/CImpExpManager.h
@@ -33,14 +33,21 @@
 #define SAKURA_CIMPEXPMANAGER_12EC6C8E_1661_485E_8972_A7A9AE419BC8_H_
 #pragma once
 
+#include "env/ShareDataAccessor.hpp"
+
 #include "CDataProfile.h"
 #include "env/DLLSHAREDATA.h"
 
 using std::wstring;
 
-class CImpExpManager
+class CImpExpManager : public ShareDataAccessorClientWithCache
 {
 public:
+	explicit CImpExpManager(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>())
+		: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
+	{
+	}
+
 	bool ImportUI(HINSTANCE hInstance, HWND hwndParent);
 	bool ExportUI(HINSTANCE hInstance, HWND hwndParent);
 	virtual bool ImportAscertain(HINSTANCE hInstance, HWND hwndParent, const wstring& sFileName, wstring& sErrMsg);
@@ -88,13 +95,12 @@ class CImpExpType : public CImpExpManager
 {
 public:
 	// Constructor
-	CImpExpType( int nIdx, STypeConfig& types, HWND hwndList )
-		: m_nIdx( nIdx )
+	explicit CImpExpType( int nIdx, STypeConfig& types, HWND hwndList, std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>() )
+		: CImpExpManager(std::move(ShareDataAccessor_))
+		, m_nIdx( nIdx )
 		, m_Types( types )
 		, m_hwndList( hwndList )
 	{
-		/* 共有データ構造体のアドレスを返す */
-		m_pShareData = &GetDllShareData();
 	}
 
 public:
@@ -115,7 +121,6 @@ private:
 	HWND			m_hwndList;
 
 	// 内部使用
-	DLLSHAREDATA*	m_pShareData;
 	int				m_nColorType;
 	wstring 		m_sColorFile;
 	bool			m_bAddType;

--- a/sakura_core/typeprop/CPropTypes.cpp
+++ b/sakura_core/typeprop/CPropTypes.cpp
@@ -84,7 +84,8 @@ GEN_PROPTYPES_CALLBACK(PropTypesKeyHelp,	CPropTypesKeyHelp)
 //                        生成と破棄                           //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
-CPropTypes::CPropTypes()
+CPropTypes::CPropTypes(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
 	{
 		assert( sizeof(CPropTypesScreen)  - sizeof(CPropTypes) == 0 );
@@ -94,9 +95,6 @@ CPropTypes::CPropTypes()
 		assert( sizeof(CPropTypesRegex)   - sizeof(CPropTypes) == 0 );
 		assert( sizeof(CPropTypesKeyHelp) - sizeof(CPropTypes) == 0 );
 	}
-
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
 
 	// Mar. 31, 2003 genta メモリ削減のためポインタに変更
 	m_pCKeyWordSetMgr = &m_pShareData->m_Common.m_sSpecialKeyword.m_CKeyWordSetMgr;
@@ -108,8 +106,6 @@ CPropTypes::CPropTypes()
 
 	(static_cast<CPropTypesScreen*>(this))->CPropTypes_Screen();
 }
-
-CPropTypes::~CPropTypes() = default;
 
 /* 初期化 */
 void CPropTypes::Create( HINSTANCE hInstApp, HWND hwndParent )

--- a/sakura_core/typeprop/CPropTypes.h
+++ b/sakura_core/typeprop/CPropTypes.h
@@ -23,6 +23,8 @@
 #define SAKURA_CPROPTYPES_2A255D3D_78BC_4B7A_85F7_7BA7ABBF3DF2_H_
 #pragma once
 
+#include "env/ShareDataAccessor.hpp"
+
 #include "types/CType.h" // STypeConfig
 
 class CPropTypes;
@@ -68,15 +70,15 @@ enum PropTypeSheetOrder {
 -----------------------------------------------------------------------*/
 /*!
 	@brief タイプ別設定ダイアログボックス
-
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
-*/
-class CPropTypes{
+ */
+class CPropTypes : public ShareDataAccessorClientWithCache
+{
 
 public:
 	//生成と破棄
-	CPropTypes();
-	~CPropTypes();
+	explicit CPropTypes(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
+	~CPropTypes() = default;
+
 	void Create(HINSTANCE hInstApp, HWND hwndParent);	//!< 初期化
 	INT_PTR DoPropertySheet(int nPageNum);		//!< プロパティシートの作成
 
@@ -99,7 +101,6 @@ protected:
 
 	//ダイアログデータ
 	PropTypeSheetOrder	m_nPageNum;
-	DLLSHAREDATA*		m_pShareData;
 	STypeConfig			m_Types;
 
 	// スクリーン用データ	2010/5/10 CPropTypes_P1_Screen.cppから移動

--- a/sakura_core/uiparts/CMenuDrawer.cpp
+++ b/sakura_core/uiparts/CMenuDrawer.cpp
@@ -35,13 +35,12 @@
 // メニューの選択色を淡くする
 #define DRAW_MENU_SELECTION_LIGHT
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
+/*!
+ * コンストラクタ
+ */
 CMenuDrawer::CMenuDrawer(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
-	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 {
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	m_hInstance = NULL;
 	m_hWndOwner = NULL;
 	m_nMenuHeight = 0;

--- a/sakura_core/uiparts/CMenuDrawer.h
+++ b/sakura_core/uiparts/CMenuDrawer.h
@@ -27,7 +27,6 @@
 class CMenuDrawer;
 
 class CImageListMgr;// 2002/2/10 aroka
-struct DLLSHAREDATA;
 
 //#define MAX_MENUPOS	10
 //	Jul. 2, 2005 genta : マクロをたくさん登録すると上限を超えてしまうので
@@ -43,10 +42,9 @@ struct DLLSHAREDATA;
 /*!
 	@brief メニュー表示＆管理
 
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 	@date 20050809 aroka クラス外部からアクセスされないメンバはprivateにした。
 */
-class CMenuDrawer : public ShareDataAccessorClient
+class CMenuDrawer : private ShareDataAccessorClientWithCache
 {
 	using Me = CMenuDrawer;
 
@@ -97,8 +95,6 @@ private:
 	int ToolbarNoToIndex( int nToolbarNo ) const;
 
 private:
-	DLLSHAREDATA*	m_pShareData;
-
 	HINSTANCE		m_hInstance;
 	HWND			m_hWndOwner;
 
@@ -136,4 +132,5 @@ protected:
 						 BYTE fsState, BYTE fsStyle, DWORD_PTR dwData,
 						 INT_PTR iString ) const;	/* TBBUTTON構造体にデータをセット */
 };
+
 #endif /* SAKURA_CMENUDRAWER_F2B94603_89D1_4064_A93E_3634A0A6FAD4_H_ */

--- a/sakura_core/window/CEditWnd.cpp
+++ b/sakura_core/window/CEditWnd.cpp
@@ -219,9 +219,11 @@ LRESULT CALLBACK CEditWndProc(
 	return ::DefWindowProc( hwnd, uMsg, wParam, lParam );
 }
 
-//	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
+/*!
+ * コンストラクタ
+ */
 CEditWnd::CEditWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
-	: ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	: ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 	, m_hWnd( NULL )
 	, m_cToolbar(GetShareDataAccessor())
 	, m_cTabWnd(GetShareDataAccessor())
@@ -252,9 +254,6 @@ CEditWnd::CEditWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 , m_IconClicked(icNone) //by 鬼(2)
 , m_nSelectCountMode( SELECT_COUNT_TOGGLE )	//文字カウント方法の初期値はSELECT_COUNT_TOGGLE→共通設定に従う
 {
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = GetShareData();
-
 	m_pcEditDoc = CEditDoc::getInstance();
 }
 

--- a/sakura_core/window/CEditWnd.h
+++ b/sakura_core/window/CEditWnd.h
@@ -96,9 +96,9 @@ struct STabGroupInfo{
 // 2007.10.30 kobake IsFuncEnable,IsFuncCheckedをFunccode.hに移動
 // 2007.10.30 kobake OnHelp_MenuItemをCEditAppに移動
 class CEditWnd
-	: public TSingleInstance<CEditWnd>
-	, public ShareDataAccessorClient
+	: private ShareDataAccessorClientWithCache
 , public CDocListenerEx
+	, public TSingleInstance<CEditWnd>
 {
 	using CViewFontPtr = std::shared_ptr<CViewFont>;
 
@@ -393,9 +393,6 @@ private:
 	int				m_nActivePaneIndex;	//!< 有効なビューのindex
 	int				m_nEditViewCount;	//!< 有効なビューの数
 	const int		m_nEditViewMaxCount;//!< ビューの最大数=4
-
-	//共有データ
-	DLLSHAREDATA*	m_pShareData;
 
 	//ヘルパ
 	CMenuDrawer		m_cMenuDrawer;

--- a/sakura_core/window/CSplitterWnd.cpp
+++ b/sakura_core/window/CSplitterWnd.cpp
@@ -34,7 +34,7 @@ constexpr auto SPLITTER_MARGIN = 2;
 //	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 CSplitterWnd::CSplitterWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 : CWnd(L"::CSplitterWnd")
-	, ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	, ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 , m_nAllSplitRows(1)					/* 分割行数 */
 , m_nAllSplitCols(1)					/* 分割桁数 */
 , m_nVSplitPos(0)					/* 垂直分割位置 */
@@ -45,19 +45,12 @@ CSplitterWnd::CSplitterWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_
 , m_nDragPosY(0)						/* ドラッグ位置Ｙ */
 , m_nActivePane(0)					/* アクティブなペイン 0-3 */
 {
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	m_hcurOld = NULL;						/* もとのマウスカーソル */
 
 	for( int v=0; v < MAXCOUNTOFVIEW; v++ ){
 		m_ChildWndArr[v] = NULL;				/* 子ウィンドウ配列 */
 	}
 	return;
-}
-
-CSplitterWnd::~CSplitterWnd()
-{
 }
 
 /* 初期化 */

--- a/sakura_core/window/CSplitterWnd.h
+++ b/sakura_core/window/CSplitterWnd.h
@@ -18,8 +18,6 @@
 
 #include "CWnd.h"
 
-struct DLLSHAREDATA;
-
 /*-----------------------------------------------------------------------
 クラスの宣言
 -----------------------------------------------------------------------*/
@@ -30,24 +28,20 @@ struct DLLSHAREDATA;
 	@brief 分割線ウィンドウクラス
 	
 	４分割ウィンドウの管理と分割線の描画を行う。
-	
-	@date 2002.2.17 YAZAKI CShareDataのインスタンスは、CProcessにひとつあるのみ。
 */
-class CSplitterWnd final : public CWnd, public ShareDataAccessorClient
+class CSplitterWnd final : public CWnd, private ShareDataAccessorClientWithCache
 {
 public:
 	/*
 	||  Constructors
 	*/
 	explicit CSplitterWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
-	~CSplitterWnd() override;
+	~CSplitterWnd() override = default;
 
 private: // 2002/2/3 aroka
 	/*
 	||  Attributes & Operations
 	*/
-	DLLSHAREDATA*	m_pShareData;
-
 	int				m_nAllSplitRows;		/* 分割行数 */
 	int				m_nAllSplitCols;		/* 分割桁数 */
 	int				m_nVSplitPos;			/* 垂直分割位置 */
@@ -93,4 +87,5 @@ protected:
 	int HitTestSplitter(int xPos, int yPos);	/* 分割バーへのヒットテスト */
 	void DrawSplitter(int xPos, int yPos, int bEraseOld);	/* 分割トラッカーの表示 */
 };
+
 #endif /* SAKURA_CSPLITTERWND_8F27B39C_B96B_4964_ACD8_E157A146F892_H_ */

--- a/sakura_core/window/CTabWnd.cpp
+++ b/sakura_core/window/CTabWnd.cpp
@@ -813,7 +813,7 @@ LRESULT CTabWnd::ExecTabCommand( int nId, POINTS pts )
 
 CTabWnd::CTabWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 : CWnd(L"::CTabWnd")
-	, ShareDataAccessorClient(std::move(ShareDataAccessor_))
+	, ShareDataAccessorClientWithCache(std::move(ShareDataAccessor_))
 , m_eTabPosition( TabPosition_None )
 , m_eDragState( DRAG_NONE )
 , m_bVisualStyle( FALSE )		// 2007.04.01 ryoji
@@ -828,21 +828,11 @@ CTabWnd::CTabWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_)
 ,m_hwndSizeBox(NULL)
 ,m_bSizeBox(false)
 {
-	/* 共有データ構造体のアドレスを返す */
-	m_pShareData = &GetDllShareData();
-
 	m_hwndTab    = NULL;
 	m_hFont      = NULL;
 	gm_pOldWndProc = NULL;
 	m_hwndToolTip = NULL;
 	m_hIml = NULL;
-
-	return;
-}
-
-CTabWnd::~CTabWnd()
-{
-	return;
 }
 
 /* ウィンドウ オープン */

--- a/sakura_core/window/CTabWnd.h
+++ b/sakura_core/window/CTabWnd.h
@@ -47,17 +47,16 @@
 
 class CGraphics;
 struct EditNode;
-struct DLLSHAREDATA;
 
 //! タブバーウィンドウ
-class CTabWnd final : public CWnd, public ShareDataAccessorClient
+class CTabWnd final : public CWnd, private ShareDataAccessorClientWithCache
 {
 public:
 	/*
 	||  Constructors
 	*/
 	explicit CTabWnd(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_);
-	~CTabWnd() override;
+	~CTabWnd() override = default;
 
 	/*
 	|| メンバ関数
@@ -171,7 +170,6 @@ protected:
 	|| メンバ変数
 	*/
 public:
-	DLLSHAREDATA*	m_pShareData;	/*!< 共有データ */
 	HFONT			m_hFont;		/*!< 表示用フォント */
 	HWND			m_hwndTab;		/*!< タブコントロール */
 	HWND			m_hwndToolTip;	/*!< ツールチップ（ボタン用） */
@@ -210,4 +208,5 @@ private:
 
 	DISALLOW_COPY_AND_ASSIGN(CTabWnd);
 };
+
 #endif /* SAKURA_CTABWND_E95D57BD_51E6_467A_9F6D_2C68BF122449_H_ */

--- a/tests/unittests/MockShareDataAccessor.hpp
+++ b/tests/unittests/MockShareDataAccessor.hpp
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "env/ShareDataAccessor.hpp"
+#include "env/DLLSHAREDATA.h"
 
 #include <gmock/gmock.h>
 #include <tuple>

--- a/tests/unittests/test-cdlgopenfile.cpp
+++ b/tests/unittests/test-cdlgopenfile.cpp
@@ -32,12 +32,37 @@
 #include "util/design_template.h"
 #include "dlg/CDlgOpenFile.h"
 
-extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog();
-extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog();
+#include "doc/CEditDoc.h"
+#include "view/CEditView.h"
 
+#include "MockShareDataAccessor.hpp"
+
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonFileDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
+extern std::shared_ptr<IDlgOpenFile> New_CDlgOpenFile_CommonItemDialog(std::shared_ptr<ShareDataAccessor> ShareDataAccessor_ = std::make_shared<ShareDataAccessor>());
+
+/*!
+ * ファイルを開くダイアログ、構築するだけ。
+ */
 TEST(CDlgOpenFile, Construct)
 {
-	CDlgOpenFile cDlgOpenFile;
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CDlgOpenFile dlg(std::move(pShareDataAccessor)); });
+}
+
+TEST(CDlgOpenFile_CommonFileDialog, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	pDllShareData->m_Common.m_sEdit.m_bVistaStyleFileDialog = false;
+	CDlgOpenFile dlg(std::move(pShareDataAccessor));
+	EXPECT_FALSE(dlg.IsItemDialog());
+}
+
+TEST(CDlgOpenFile_CommonItemDialog, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	pDllShareData->m_Common.m_sEdit.m_bVistaStyleFileDialog = true;
+	CDlgOpenFile dlg(std::move(pShareDataAccessor));
+	EXPECT_TRUE(dlg.IsItemDialog());
 }
 
 TEST(CDlgOpenFile, DISABLED_CommonItemDialogCreate)

--- a/tests/unittests/test-cformatmanager.cpp
+++ b/tests/unittests/test-cformatmanager.cpp
@@ -1,0 +1,37 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2023, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "env/CFormatManager.h"
+
+#include "MockShareDataAccessor.hpp"
+
+/*!
+ * 構築するだけ。
+ */
+
+TEST(CFormatManager, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CFormatManager mgr(std::move(pShareDataAccessor)); });
+}

--- a/tests/unittests/test-chelpmanager.cpp
+++ b/tests/unittests/test-chelpmanager.cpp
@@ -1,0 +1,127 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2023, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "env/CHelpManager.h"
+
+#include "MockShareDataAccessor.hpp"
+
+/*!
+ * 構築するだけ。
+ */
+TEST(CHelpManager, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CHelpManager mgr(std::move(pShareDataAccessor)); });
+}
+
+TEST(CHelpManager, ExtWinHelpIsSet)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	CHelpManager mgr(std::move(pShareDataAccessor));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHelp, L"");
+	EXPECT_FALSE(mgr.ExtWinHelpIsSet(nullptr));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHelp, L"何か");
+	EXPECT_TRUE(mgr.ExtWinHelpIsSet(nullptr));
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHelp, L"");
+
+	auto typeConfig = std::make_unique<STypeConfig>();
+	typeConfig->m_szExtHelp = L"何か";
+	EXPECT_TRUE(mgr.ExtWinHelpIsSet(typeConfig.get()));
+
+	typeConfig->m_szExtHelp = L"";
+	EXPECT_FALSE(mgr.ExtWinHelpIsSet(typeConfig.get()));
+}
+
+TEST(CHelpManager, GetExtWinHelp)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	CHelpManager mgr(std::move(pShareDataAccessor));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHelp, L"何か1");
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_szExtHelp, mgr.GetExtWinHelp(nullptr));
+
+	auto typeConfig = std::make_unique<STypeConfig>();
+	typeConfig->m_szExtHelp = L"何か2";
+	EXPECT_EQ(typeConfig->m_szExtHelp, mgr.GetExtWinHelp(typeConfig.get()));
+
+	typeConfig->m_szExtHelp = L"";
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_szExtHelp, mgr.GetExtWinHelp(typeConfig.get()));
+}
+
+TEST(CHelpManager, ExtHTMLHelpIsSet)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	CHelpManager mgr(std::move(pShareDataAccessor));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, L"");
+	EXPECT_FALSE(mgr.ExtHTMLHelpIsSet(nullptr));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, L"何か");
+	EXPECT_TRUE(mgr.ExtHTMLHelpIsSet(nullptr));
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, L"");
+
+	auto typeConfig = std::make_unique<STypeConfig>();
+
+	typeConfig->m_szExtHtmlHelp = L"何か";
+	EXPECT_TRUE(mgr.ExtHTMLHelpIsSet(typeConfig.get()));
+
+	typeConfig->m_szExtHtmlHelp = L"";
+	EXPECT_FALSE(mgr.ExtHTMLHelpIsSet(typeConfig.get()));
+}
+
+TEST(CHelpManager, GetExtHTMLHelp)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	CHelpManager mgr(std::move(pShareDataAccessor));
+
+	wcscpy_s(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, L"何か1");
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, mgr.GetExtHTMLHelp(nullptr));
+
+	auto typeConfig = std::make_unique<STypeConfig>();
+	typeConfig->m_szExtHtmlHelp = L"何か2";
+	EXPECT_EQ(typeConfig->m_szExtHtmlHelp, mgr.GetExtHTMLHelp(typeConfig.get()));
+
+	typeConfig->m_szExtHtmlHelp = L"";
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_szExtHtmlHelp, mgr.GetExtHTMLHelp(typeConfig.get()));
+}
+
+TEST(CHelpManager, HTMLHelpIsSingle)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	CHelpManager mgr(std::move(pShareDataAccessor));
+
+	auto typeConfig = std::make_unique<STypeConfig>();
+	typeConfig->m_bHtmlHelpIsSingle = true;
+
+	pDllShareData->m_Common.m_sHelper.m_bHtmlHelpIsSingle = false;
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_bHtmlHelpIsSingle, mgr.HTMLHelpIsSingle(nullptr));
+
+	typeConfig->m_szExtHtmlHelp = L"何か2";
+	EXPECT_EQ(typeConfig->m_bHtmlHelpIsSingle, mgr.HTMLHelpIsSingle(typeConfig.get()));
+
+	typeConfig->m_szExtHtmlHelp = L"";
+	EXPECT_EQ(pDllShareData->m_Common.m_sHelper.m_bHtmlHelpIsSingle, mgr.HTMLHelpIsSingle(typeConfig.get()));
+}

--- a/tests/unittests/test-cimpexpmanager.cpp
+++ b/tests/unittests/test-cimpexpmanager.cpp
@@ -1,0 +1,39 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2023, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "typeprop/CImpExpManager.h"
+
+#include "MockShareDataAccessor.hpp"
+
+/*!
+ * 構築するだけ。
+ */
+TEST(CImpExpType, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	int         nIdx = 1;
+	STypeConfig types = {};
+	const auto  hwndList= (HWND)nullptr;
+	EXPECT_NO_THROW({ CImpExpType dlg(nIdx, types, hwndList, std::move(pShareDataAccessor)); });
+}

--- a/tests/unittests/test-cproptypes.cpp
+++ b/tests/unittests/test-cproptypes.cpp
@@ -1,0 +1,36 @@
+﻿/*! @file */
+/*
+	Copyright (C) 2023, Sakura Editor Organization
+
+	This software is provided 'as-is', without any express or implied
+	warranty. In no event will the authors be held liable for any damages
+	arising from the use of this software.
+
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+
+		1. The origin of this software must not be misrepresented;
+		   you must not claim that you wrote the original software.
+		   If you use this software in a product, an acknowledgment
+		   in the product documentation would be appreciated but is
+		   not required.
+
+		2. Altered source versions must be plainly marked as such,
+		   and must not be misrepresented as being the original software.
+
+		3. This notice may not be removed or altered from any source
+		   distribution.
+ */
+#include "typeprop/CPropTypes.h"
+
+#include "MockShareDataAccessor.hpp"
+
+/*!
+ * タイプ別設定ダイアログ、構築するだけ。
+ */
+TEST(CPropTypes, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CPropTypes dlg(std::move(pShareDataAccessor)); });
+}

--- a/tests/unittests/test-csharedata.cpp
+++ b/tests/unittests/test-csharedata.cpp
@@ -22,19 +22,16 @@
 		3. This notice may not be removed or altered from any source
 		   distribution.
 */
-#include <gtest/gtest.h>
-
-#include <tchar.h>
-#include <Windows.h>
-#include <windowsx.h>
-#include <Shlwapi.h>
-
-#include <memory>
-
 #include "env/CShareData.h"
+#include "env/DLLSHAREDATA.h"
 
 #include "_main/CCommandLine.h"
 #include "_main/CNormalProcess.h"
+
+#include "doc/CEditDoc.h"
+#include "view/CEditView.h"
+
+#include "MockShareDataAccessor.hpp"
 
 /*!
  * @brief CShareDataのテスト
@@ -61,4 +58,16 @@ TEST( CShareData, test )
 	CSelectLang::ChangeLang(L"sakura_lang_en_US.dll");
 	pShareData->ConvertLangValues(values, false);
 	pShareData->RefreshString();
+}
+
+TEST(CSearchKeywordManager, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CSearchKeywordManager mgr(std::move(pShareDataAccessor)); });
+}
+
+TEST(CTagJumpManager, Construct)
+{
+	auto [pDllShareData, pShareDataAccessor] = MakeDummyShareData();
+	EXPECT_NO_THROW({ CTagJumpManager mgr(std::move(pShareDataAccessor)); });
 }

--- a/tests/unittests/tests1.vcxproj
+++ b/tests/unittests/tests1.vcxproj
@@ -138,8 +138,12 @@
     <ClCompile Include="test-cdoclinemgr.cpp" />
     <ClCompile Include="test-ceditdoc.cpp" />
     <ClCompile Include="test-ceditwnd.cpp" />
+    <ClCompile Include="test-cformatmanager.cpp" />
+    <ClCompile Include="test-chelpmanager.cpp" />
     <ClCompile Include="test-chokanmgr.cpp" />
+    <ClCompile Include="test-cimpexpmanager.cpp" />
     <ClCompile Include="test-cppa.cpp" />
+    <ClCompile Include="test-cproptypes.cpp" />
     <ClCompile Include="test-csearchagent.cpp" />
     <ClCompile Include="test-crunningtimer.cpp" />
     <ClCompile Include="test-csharedata.cpp" />

--- a/tests/unittests/tests1.vcxproj.filters
+++ b/tests/unittests/tests1.vcxproj.filters
@@ -255,6 +255,18 @@
     <ClCompile Include="test-cdlgfind.cpp">
       <Filter>Test Files</Filter>
     </ClCompile>
+    <ClCompile Include="test-cimpexpmanager.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-cproptypes.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-chelpmanager.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
+    <ClCompile Include="test-cformatmanager.cpp">
+      <Filter>Test Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StartEditorProcessForTest.h">


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

- 改善
- 不具合修正

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
* もともと、共有メモリにアクセスするクラスは、単体テストを書けないという問題がありました。
* この問題に対しては 22f69749ea84d9b27601e5ecd82df447125d2049 で導入した `ShareDataAccessorClient` である程度対応できることが分かっています。
* 既に導入した実装では `CControlTray` をテスト可能とするときに問題が出ることが分かったので、改良版クラスを導入して対処を試みます。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
* #13 
  で導入した `ShareDataAccessorClient` を改良します。

### 関連するクラスの説明
|No.|クラス名|役割|
|--|--|--|
|1|`ShareDataAccessor`|グローバル関数`GetDllShareData()`の呼び出しをラップします。|
|2|`ShareDataAccessorClient`|共有メモリに依存するクラスの基底クラスです。`ShareDataAccessor`を介した共有メモリへのアクセス機能を提供します。|
|3|`ShareDataAccessorClientWithCache`|メンバー変数 `m_pShareData` に共有メモリのアドレスをキャッシュするクラスの基底クラスです。コンストラクタでメンバー変数を初期化します。このPRで追加する新規クラスです。|

### 削除するメソッド
* `ShareDataAccessorClient::GetDllShareData()`を削除します。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
