### PR TITLE
https://github.com/sakura-editor/sakura/pull/1953 の変更内容追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 
 [Visual Studio 2017]: https://visualstudio.microsoft.com/ja/vs/older-downloads/ "Visual Studio 以前のバージョン"
 [Visual Studio 2022]: https://visualstudio.microsoft.com/ja/downloads/ "Visual Studio 最新版"
+[ライセンスの OSI のページ]: https://opensource.org/license/zlib
+[Visual Studio Community ライセンス]: https://visualstudio.microsoft.com/ja/license-terms/vs2022-ga-community/
 [Markdown をローカルで確認する方法]: https://github.com/sakura-editor/sakura/wiki/markdown-%E3%82%92%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%81%A7%E7%A2%BA%E8%AA%8D%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95
 [How to extract currently installed Visual Studio component IDs?]: https://stackoverflow.com/questions/52946333/how-to-extract-currently-installed-visual-studio-component-ids
 [Configure Visual Studio across your organization with .vsconfig]: https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/
@@ -73,6 +75,8 @@ https://github.com/sakura-editor/sakura/wiki
 
 Sakura Editor をコンパイルするためには、 
 [最新のVisual Studio][Visual Studio 2022] または [以前のバージョンのVisual Studio（Visual Studio 2017 以降。ただし Express 2017 for Windows Desktop は除く）][Visual Studio 2017]が必要です。
+
+Sakura Editor は、[Open Source Initiative (OSI) 認定ライセンスである zlib ライセンス][ライセンスの OSI のページ][に基づいている](LICENSE)ため、[通常 Community エディションの対象外であるエンタープライズ組織でも、特例で Community エディションを利用しての開発・テストができます。][Visual Studio Community ライセンス]もちろん、Professional・Enterprise エディションも利用できます。
 
 正式バイナリは [Visual Studio Community 2017][Visual Studio 2017] でビルドされます。
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
   - [開発参加ポリシー](#開発参加ポリシー)
   - [Build Requirements](#build-requirements)
     - [Visual Studio Install options required](#visual-studio-install-options-required)
-    - [Visual Studio 2019 対応に関して](#visual-studio-2019-対応に関して)
+    - [Visual Studio 2019 以降の対応に関して](#visual-studio-2019-以降の対応に関して)
     - [.vsconfig に関して](#vsconfig-に関して)
-      - [Visual Studio 2017/2019/2022 共通](#visual-studio-201720192022-共通)
+      - [Visual Studio 2017 以降共通](#visual-studio-2017-以降共通)
       - [Visual Studio 2019 以降のみ](#visual-studio-2019-以降のみ)
       - [参照](#参照)
   - [How to build](#how-to-build)
@@ -83,18 +83,24 @@ Sakura Editor は、[Open Source Initiative (OSI) 認定ライセンスである
 ### Visual Studio Install options required
 - Windows 10 SDK
 
-### Visual Studio 2019 対応に関して
+### Visual Studio 2019 以降の対応に関して
 
-Visual Studio 2017/2019 の両対応に関しては  [#866](https://github.com/sakura-editor/sakura/issues/866) で対処済みです。  
+| Visual Studioバージョン | 対応済みIssue/PR                                           |
+| ----------------------- | ---------------------------------------------------------- |
+| 2022                    | [#1872](https://github.com/sakura-editor/sakura/pull/1872)（[コミット][2022対応コミット]） |
+| 2017/2019同時           | [#866](https://github.com/sakura-editor/sakura/issues/866) |
+
+[2022対応コミット]: https://github.com/sakura-editor/sakura/pull/1872/commits/93cf3f3eacfed6a4d0a2c30d5445b53b2599db3c
+
 [仕組みに関してはこちらを参照](vcx-props/project-PlatformToolset.md)
 
 ### .vsconfig に関して
 
-Sakura Editor のコンパイルに必要なコンポーネントを Visual Studio 2017/2019/2022 にインストールするために [.vsconfig](.vsconfig) という設定ファイルを用意しています。
+Sakura Editor のコンパイルに必要なコンポーネントを Visual Studio 2017 以降にインストールするために [.vsconfig](.vsconfig) という設定ファイルを用意しています。
 
 [#1162](https://github.com/sakura-editor/sakura/pull/1162) で [.vsconfig](.vsconfig) というファイルを sakura.sln と同じディレクトリに配置しています。
 
-#### Visual Studio 2017/2019/2022 共通
+#### Visual Studio 2017 以降共通
 
 `vs_community__XXXXX.exe` でインストールする際に、--config オプションをつけてインストールする。
 あるいは構成変更することにより、必要なコンポーネントを自動的にインストールします。

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ https://github.com/sakura-editor/sakura/wiki
 ## Build Requirements
 
 Sakura Editor をコンパイルするためには、 
-[最新のVisual Studio][Visual Studio 2022] または [以前のバージョンのVisual Studio(Visual Studio 2017 以降)][Visual Studio 2017] が必要です。
+[最新のVisual Studio][Visual Studio 2022] または [以前のバージョンのVisual Studio（Visual Studio 2017 以降。ただし Express 2017 for Windows Desktop は除く）][Visual Studio 2017]が必要です。
 
 正式バイナリは [Visual Studio Community 2017][Visual Studio 2017] でビルドされます。
 

--- a/vcx-props/project-PlatformToolset.md
+++ b/vcx-props/project-PlatformToolset.md
@@ -20,6 +20,7 @@ Visual Studio の各バージョンごとにデフォルトの PlatformToolset (
 |--|--|
 |Visual Studio 2017|v141|
 |Visual Studio 2019|v142|
+|Visual Studio 2022|v143|
 
 ## 異なる Visual Studio のバージョンで開いたときの動作
 


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/pull/1952 に https://github.com/sakura-editor/sakura/pull/1953 の修正内容を取り込む形のPRです。

- project-PlatformToolset.mdを2022対応に合わせて修正
- Express 2017 for Windows Desktopは対象外であることを明記（以前に「Community or Professional以上」と書いていたため。他のExpress派生は2015が最後）
- 企業でもCommunity版を使って貢献できることを明記（メインの利用者にCommunity版対象外の企業構成員が多いため）
- Visual Studio 2025以降を見据えた表記に修正（多分今秋頃に出る。今の形だといずれ`/`の数がすごいことになる）

マージされたら https://github.com/sakura-editor/sakura/pull/1953 はクローズします